### PR TITLE
chore(deps): prepare for PHP8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "^7.0",
-        "tightenco/collect": "^v8.0"
+        "tightenco/collect": "^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
DropBox V2 doesn't have an official PHP SDK, we still need to keep this Repo alive a little bit longer....